### PR TITLE
Fix upstream Opal compatibility issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "vendor/ruby-ll"]
 	path = vendor/ruby-ll
 	url = https://github.com/plurimath-js/ruby-ll
+[submodule "vendor/opal"]
+	path = vendor/opal
+	url = https://github.com/plurimath-js/opal

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem 'oga', path: 'vendor/oga'
 gem 'equivalent-xml', path: 'vendor/equivalent-xml'
 gem 'ruby-ll', path: 'vendor/ruby-ll'
 gem 'htmlentities', path: 'vendor/htmlentities'
+gem 'opal', path: 'vendor/opal'
 
-gem 'opal', git: "https://github.com/opal/opal.git", ref: "e5385d54c95e65c3c4bbbc1728f71f098526937c"
 gem 'opal-rspec', git: "https://github.com/opal/opal-rspec.git", submodules: true
 
 gem 'nokogiri'


### PR DESCRIPTION
This corrects a problem introduced recently with return handling and makes us use a version of Opal that is up to be released soon as 1.8.0.